### PR TITLE
Add tray control to pause wake word

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Desktop voice application for Home Assistant with visual animations and VAD (Voi
 - **WebRTC VAD** - Smart speech detection (doesn't react to every fridge beep)
 - **Visual animations** - Three.js with shaders and FFT audio analysis (because a simple circle is not enough)
 - **Tray integration** - Lives in system tray like a proper application
+- **Pause wake word** - Quickly pause or resume detection from tray
 - **Pipeline selection** - Choose your preferred assistant pipeline
 - **Transparent window** - Doesn't block your desktop (finally, someone thought about it)
 


### PR DESCRIPTION
## Summary
- allow wake word detection to be paused/resumed from tray
- update tray menu dynamically when wake word state changes
- document new tray feature

## Testing
- `python -m py_compile main.py wake_word_detector.py`

------
https://chatgpt.com/codex/tasks/task_b_6841740892e8832cb14eab6ac0c33ddb