### PR TITLE
Fix WebKit2 version detection for Ubuntu 24.04+ compatibility

### DIFF
--- a/platform_utils.py
+++ b/platform_utils.py
@@ -14,19 +14,29 @@ def check_linux_dependencies():
     """Check if all required Linux dependencies are available."""
     if platform.system() != "Linux":
         return True
-    
+
     missing = []
-    
+
     # Check GTK/WebKit for webview
     try:
         import gi
         gi.require_version('Gtk', '3.0')
-        gi.require_version('WebKit2', '4.0')
+
+        # Try WebKit2 4.1 first (newer), then fall back to 4.0
+        try:
+            gi.require_version('WebKit2', '4.1')
+        except ValueError:
+            try:
+                gi.require_version('WebKit2', '4.0')
+            except ValueError:
+                missing.append("gir1.2-webkit2-4.0 or gir1.2-webkit2-4.1")
+
         from gi.repository import Gtk, WebKit2
     except ImportError:
-        missing.append("python3-gi, gir1.2-gtk-3.0, gir1.2-webkit2-4.0")
-    except ValueError:
-        missing.append("gtk3-devel, webkit2gtk3-devel")
+        missing.append("python3-gi, gir1.2-gtk-3.0, gir1.2-webkit2-4.0/4.1")
+    except ValueError as e:
+        logger.warning(f"GTK/WebKit version error: {e}")
+        missing.append("gir1.2-gtk-3.0, gir1.2-webkit2-4.0 or gir1.2-webkit2-4.1")
     
     # Check audio
     try:
@@ -44,8 +54,11 @@ def check_linux_dependencies():
         for dep in missing:
             print(f"   • {dep}")
         print("\nInstall with:")
+        print("# For Ubuntu 22.04 and older:")
         print("sudo apt install python3-gi python3-gi-cairo gir1.2-gtk-3.0 gir1.2-webkit2-4.0 python3-pyaudio portaudio19-dev")
-        print("or run: ./install-linux.sh")
+        print("\n# For Ubuntu 24.04+ / Debian 13+:")
+        print("sudo apt install python3-gi python3-gi-cairo gir1.2-gtk-3.0 gir1.2-webkit2-4.1 python3-pyaudio portaudio19-dev")
+        print("\nor run: ./install-linux.sh")
         return False
     
     return True


### PR DESCRIPTION
Fixes false dependency error when WebKit2 4.1 is installed instead of 4.0.

Problem:
- Code hardcoded WebKit2 version 4.0
- Ubuntu 24.04+, Mint 22, Debian 13 ship with WebKit2 4.1
- ValueError was caught and displayed incorrect "gtk3-devel" error
- User had all correct packages but app showed missing dependencies

Solution:
- Try WebKit2 4.1 first (newer systems)
- Fallback to WebKit2 4.0 (older systems)
- Remove confusing Fedora package names from error messages
- Update install instructions to show both versions

Changes:
- Add nested try/except for WebKit2 version detection
- Try 4.1 first, then 4.0 as fallback
- Show clear error messages with both package options
- Update help text with version-specific install commands

Testing:
- Python syntax verified
- Logic handles both WebKit2 versions gracefully
- Clear error messages for users

Fixes: User reported "gtk3-devel, webkit2gtk3-devel" missing despite having all packages installed (gir1.2-webkit2-4.1)