### PR TITLE
Add --settings command line option for quick configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,16 @@ DEBUG=false
 
 ### 4. Run
 ```bash
+# Run application normally
 python main.py
+
+# Or open settings directly
+python main.py --settings
 ```
+
+**Command line options:**
+- `--settings` - Opens settings window without starting the full application (useful for quick configuration)
+- `--help` - Shows all available command line options
 
 **Pro tip:** Use the installer unless you want to modify the code. It's way fucking easier.
 
@@ -285,10 +293,18 @@ Once converted, place your `your_model.onnx` file in the `models/` directory and
 
 ## 🎯 Usage
 
+### Command Line Options
+```bash
+python main.py              # Run application normally
+python main.py --settings   # Open settings only (quick configuration)
+python main.py --help       # Show all command line options
+```
+
 ### Voice activation
 - **Hotkey**: `Ctrl+Shift+H` (default)
 - **Wake word**: Say "Alexa" or other configured wake words
 - **Tray menu**: Right click on tray icon
+- **Settings shortcut**: Run with `--settings` flag
 
 ### Application states
 - **🔵 Listening** - Listening to your speech

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ import threading
 import webview
 import sys
 import os
+import argparse
 import pystray
 from PIL import Image, ImageDraw
 from pystray import MenuItem as item
@@ -1062,6 +1063,26 @@ def validate_configuration():
 
 def main():
     """Main application function with configuration validation."""
+    # Parse command line arguments
+    parser = argparse.ArgumentParser(description='GLaSSIST - Voice Assistant for Home Assistant')
+    parser.add_argument('--settings', action='store_true',
+                        help='Open settings window directly without starting the application')
+    args = parser.parse_args()
+
+    # If --settings flag is present, open settings and exit
+    if args.settings:
+        print("=== GLaSSIST SETTINGS ===")
+        print("Opening settings window...")
+        try:
+            from flet_settings import show_flet_settings
+            show_flet_settings(animation_server=None)
+            return
+        except Exception as e:
+            print(f"Error opening settings: {e}")
+            import traceback
+            traceback.print_exc()
+            sys.exit(1)
+
     # Set UTF-8 encoding for console output on Windows
     import sys
     if sys.platform == "win32":
@@ -1072,7 +1093,7 @@ def main():
         except:
             # Fallback for older Python versions
             os.environ["PYTHONIOENCODING"] = "utf-8"
-    
+
     print("=== GLaSSIST DESKTOP ===")
     print("Starting application...")
     print("Pre-initializing audio system...")


### PR DESCRIPTION
Adds ability to open settings window directly without starting full application.

Changes:
- Add argparse import to main.py
- Parse --settings command line flag
- If --settings present, open settings window and exit
- Update README.md with command line options documentation
- Add examples to both Installation and Usage sections

Usage:
  python main.py              # Normal start
  python main.py --settings   # Open settings only
  python main.py --help       # Show help

Benefits:
- Quick access to settings without running full app
- Useful for initial configuration
- Lighter weight than starting entire application
- Better user experience for configuration tasks

Implementation:
- Uses existing show_flet_settings() function
- Passes None for animation_server (not needed for settings)
- Exits cleanly after settings window closes
- Maintains backward compatibility (no args = normal run)