### PR TITLE
Frontend: WebGL fallback + subtle idle glow when context creation fails

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -840,6 +840,10 @@
         window.addEventListener('load', function() {
             console.log('Initializing application with error and success text support...');
             initThree();
+            // Start rendering immediately so hidden-state idle glow is visible at startup.
+            if (!isAnimating) {
+                startAnimation();
+            }
             initWebSocket();
             startHeartbeat();
         });

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -27,6 +27,12 @@
             position: relative;
             background: transparent;
         }
+
+        html.fallback-mode,
+        body.fallback-mode,
+        #container.fallback-mode {
+            background: #0f1418;
+        }
         
         #canvas {
             display: block;
@@ -307,6 +313,14 @@
             const canvas = document.getElementById('canvas');
             fallbackCtx = canvas.getContext('2d');
             useCanvasFallback = !!fallbackCtx;
+            if (useCanvasFallback) {
+                document.documentElement.classList.add('fallback-mode');
+                document.body.classList.add('fallback-mode');
+                const container = document.getElementById('container');
+                if (container) {
+                    container.classList.add('fallback-mode');
+                }
+            }
             resizeFallbackCanvas();
             clearFallbackCanvas();
         }
@@ -402,7 +416,9 @@
             
             // Show appropriate elements based on state
             if (currentState !== 'hidden') {
-                ring.visible = true;
+                if (ring) {
+                    ring.visible = true;
+                }
                 
                 // Show error text only in error state
                 if (currentState === 'error') {
@@ -426,7 +442,9 @@
             console.log('Stopping animation');
             
             // Hide all elements
-            ring.visible = false;
+            if (ring) {
+                ring.visible = false;
+            }
             
             // Hide all texts
             hideErrorText();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -345,29 +345,36 @@
             if (!fallbackCtx) return;
 
             clearFallbackCanvas();
-            if (currentState === 'hidden') return;
 
             const cx = window.innerWidth / 2;
             const cy = window.innerHeight / 2;
+            const isHiddenState = currentState === 'hidden';
             const radiusBase = Math.min(window.innerWidth, window.innerHeight) * 0.22;
             const audioPulse = 1 + Math.min(audioLevel, 1) * 0.22;
             const timedPulse = 1 + 0.08 * Math.sin(time * 4.0);
-            const pulse = (currentState === 'listening' || currentState === 'responding') ? audioPulse : timedPulse;
+            const idlePulse = 1 + 0.02 * Math.sin(time * 1.6);
+            const pulse = isHiddenState
+                ? idlePulse
+                : ((currentState === 'listening' || currentState === 'responding') ? audioPulse : timedPulse);
             const radius = radiusBase * pulse;
-            const color = stateColorToCss(currentState);
+            const color = isHiddenState ? '#2e5166' : stateColorToCss(currentState);
+            const outerWidth = isHiddenState ? 8 : 18;
+            const innerWidth = isHiddenState ? 3 : 5;
+            const shadowBlur = isHiddenState ? 14 : 30;
+            const secondaryAlpha = isHiddenState ? 0.35 : 0.6;
 
             fallbackCtx.save();
             fallbackCtx.globalCompositeOperation = 'lighter';
             fallbackCtx.strokeStyle = color;
-            fallbackCtx.lineWidth = 18;
+            fallbackCtx.lineWidth = outerWidth;
             fallbackCtx.shadowColor = color;
-            fallbackCtx.shadowBlur = 30;
+            fallbackCtx.shadowBlur = shadowBlur;
             fallbackCtx.beginPath();
             fallbackCtx.arc(cx, cy, radius, 0, Math.PI * 2);
             fallbackCtx.stroke();
 
-            fallbackCtx.lineWidth = 5;
-            fallbackCtx.globalAlpha = 0.6;
+            fallbackCtx.lineWidth = innerWidth;
+            fallbackCtx.globalAlpha = secondaryAlpha;
             fallbackCtx.beginPath();
             fallbackCtx.arc(cx, cy, radius + 10, 0, Math.PI * 2);
             fallbackCtx.stroke();
@@ -640,6 +647,14 @@
                 
                 // Update parameters based on state
                 switch (currentState) {
+                    case 'hidden':
+                        // Subtle idle glow so users know the app is alive.
+                        ring.material.uniforms.color.value.set(0x2e5166);
+                        ring.material.uniforms.pulseSpeed.value = 0.8;
+                        ring.material.uniforms.audioLevel.value = 0.05;
+                        ring.material.uniforms.usePulse.value = 1.0;
+                        break;
+
                     case 'listening':
                         // Listening: reacts only to sound
                         ring.material.uniforms.audioLevel.value = audioLevel;
@@ -710,7 +725,12 @@
             }
             
             if (newState === 'hidden') {
-                stopAnimation();
+                if (ring) {
+                    ring.visible = true;
+                }
+                if (!isAnimating) {
+                    startAnimation();
+                }
                 return;
             } 
             

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -142,6 +142,8 @@
         // Global variables
         let scene, camera, renderer, animationFrameId;
         let ring;
+        let useCanvasFallback = false;
+        let fallbackCtx = null;
         let websocket = null;
         let currentState = 'hidden';
         let audioData = [];
@@ -171,6 +173,11 @@
             success: 0x4caf50,
             connecting: 0xffeb3b
         };
+
+        function stateColorToCss(state) {
+            const color = stateColors[state] || stateColors.hidden;
+            return `#${color.toString(16).padStart(6, '0')}`;
+        }
         
         // SHADER WITH GRADIENT AND EFFECTS
         const ringVertexShader = `
@@ -270,26 +277,87 @@
         
         // Three.js initialization
         function initThree() {
-            scene = new THREE.Scene();
-            scene.background = null;
-            
-            camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
-            camera.position.z = 5;
-            
-            renderer = new THREE.WebGLRenderer({ 
-                canvas: document.getElementById('canvas'),
-                antialias: true,
-                alpha: true,
-                premultipliedAlpha: false
-            });
-            renderer.setSize(window.innerWidth, window.innerHeight);
-            renderer.setPixelRatio(window.devicePixelRatio);
-            renderer.setClearColor(0x000000, 0);
-            
-            createAnimations();
-            
-            renderer.render(scene, camera);
-            console.log('Three.js initialized with error and success text support');
+            try {
+                scene = new THREE.Scene();
+                scene.background = null;
+
+                camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+                camera.position.z = 5;
+
+                renderer = new THREE.WebGLRenderer({
+                    canvas: document.getElementById('canvas'),
+                    antialias: true,
+                    alpha: true,
+                    premultipliedAlpha: false
+                });
+                renderer.setSize(window.innerWidth, window.innerHeight);
+                renderer.setPixelRatio(window.devicePixelRatio);
+                renderer.setClearColor(0x000000, 0);
+
+                createAnimations();
+                renderer.render(scene, camera);
+                console.log('Three.js initialized with error and success text support');
+            } catch (error) {
+                console.warn('WebGL initialization failed, using canvas fallback:', error);
+                initCanvasFallback();
+            }
+        }
+
+        function initCanvasFallback() {
+            const canvas = document.getElementById('canvas');
+            fallbackCtx = canvas.getContext('2d');
+            useCanvasFallback = !!fallbackCtx;
+            resizeFallbackCanvas();
+            clearFallbackCanvas();
+        }
+
+        function resizeFallbackCanvas() {
+            if (!fallbackCtx) return;
+            const canvas = fallbackCtx.canvas;
+            const dpr = window.devicePixelRatio || 1;
+            canvas.width = Math.max(1, Math.floor(window.innerWidth * dpr));
+            canvas.height = Math.max(1, Math.floor(window.innerHeight * dpr));
+            canvas.style.width = `${window.innerWidth}px`;
+            canvas.style.height = `${window.innerHeight}px`;
+            fallbackCtx.setTransform(dpr, 0, 0, dpr, 0, 0);
+        }
+
+        function clearFallbackCanvas() {
+            if (!fallbackCtx) return;
+            fallbackCtx.clearRect(0, 0, window.innerWidth, window.innerHeight);
+        }
+
+        function renderFallbackRing(audioLevel, time) {
+            if (!fallbackCtx) return;
+
+            clearFallbackCanvas();
+            if (currentState === 'hidden') return;
+
+            const cx = window.innerWidth / 2;
+            const cy = window.innerHeight / 2;
+            const radiusBase = Math.min(window.innerWidth, window.innerHeight) * 0.22;
+            const audioPulse = 1 + Math.min(audioLevel, 1) * 0.22;
+            const timedPulse = 1 + 0.08 * Math.sin(time * 4.0);
+            const pulse = (currentState === 'listening' || currentState === 'responding') ? audioPulse : timedPulse;
+            const radius = radiusBase * pulse;
+            const color = stateColorToCss(currentState);
+
+            fallbackCtx.save();
+            fallbackCtx.globalCompositeOperation = 'lighter';
+            fallbackCtx.strokeStyle = color;
+            fallbackCtx.lineWidth = 18;
+            fallbackCtx.shadowColor = color;
+            fallbackCtx.shadowBlur = 30;
+            fallbackCtx.beginPath();
+            fallbackCtx.arc(cx, cy, radius, 0, Math.PI * 2);
+            fallbackCtx.stroke();
+
+            fallbackCtx.lineWidth = 5;
+            fallbackCtx.globalAlpha = 0.6;
+            fallbackCtx.beginPath();
+            fallbackCtx.arc(cx, cy, radius + 10, 0, Math.PI * 2);
+            fallbackCtx.stroke();
+            fallbackCtx.restore();
         }
         
         function createAnimations() {
@@ -321,7 +389,9 @@
             
             animationFrameId = requestAnimationFrame(animate);
             updateAnimation();
-            renderer.render(scene, camera);
+            if (renderer && scene && camera) {
+                renderer.render(scene, camera);
+            }
         }
         
         function startAnimation() {
@@ -367,7 +437,11 @@
                 animationFrameId = null;
             }
             
-            renderer.render(scene, camera);
+            if (renderer && scene && camera) {
+                renderer.render(scene, camera);
+            } else {
+                clearFallbackCanvas();
+            }
         }
         
         function showErrorText(message) {
@@ -532,6 +606,11 @@
             
             // Process audio data with normalization
             const audioLevel = processAudioLevel(audioData);
+
+            if (useCanvasFallback) {
+                renderFallbackRing(audioLevel, time);
+                return;
+            }
             
             // Update ring shader
             if (ring && ring.material.uniforms) {
@@ -699,9 +778,17 @@
         });
         
         window.addEventListener('resize', function() {
-            camera.aspect = window.innerWidth / window.innerHeight;
-            camera.updateProjectionMatrix();
-            renderer.setSize(window.innerWidth, window.innerHeight);
+            if (camera) {
+                camera.aspect = window.innerWidth / window.innerHeight;
+                camera.updateProjectionMatrix();
+            }
+            if (renderer) {
+                renderer.setSize(window.innerWidth, window.innerHeight);
+            }
+            if (useCanvasFallback) {
+                resizeFallbackCanvas();
+                renderFallbackRing(processAudioLevel(audioData), performance.now() * 0.001);
+            }
         });
         
         function startHeartbeat() {

--- a/utils.py
+++ b/utils.py
@@ -223,7 +223,11 @@ def play_audio_from_url(url, host, animation_server=None, done_callback=None):
     
     try:
         import re as _re
-        _is_local = os.path.isabs(url) or _re.match(r'^[A-Za-z]:[/\\]', url)
+        _is_windows_abs = bool(_re.match(r'^[A-Za-z]:[/\\]', str(url)))
+        _looks_abs = os.path.isabs(url) or _is_windows_abs
+        # HA TTS URLs look like "/api/tts_proxy/..." and must be fetched via HTTP.
+        # Treat as local only if the path actually exists on disk.
+        _is_local = _looks_abs and os.path.exists(url)
 
         if _is_local:
             local_path = os.path.normpath(url)

--- a/utils.py
+++ b/utils.py
@@ -223,11 +223,7 @@ def play_audio_from_url(url, host, animation_server=None, done_callback=None):
     
     try:
         import re as _re
-        _is_windows_abs = bool(_re.match(r'^[A-Za-z]:[/\\]', str(url)))
-        _looks_abs = os.path.isabs(url) or _is_windows_abs
-        # HA TTS URLs look like "/api/tts_proxy/..." and must be fetched via HTTP.
-        # Treat as local only if the path actually exists on disk.
-        _is_local = _looks_abs and os.path.exists(url)
+        _is_local = os.path.isabs(url) or _re.match(r'^[A-Za-z]:[/\\]', url)
 
         if _is_local:
             local_path = os.path.normpath(url)


### PR DESCRIPTION
## Summary
Adds a resilient frontend fallback for environments where WebGL context creation fails (seen with Qt webview on some Linux stacks).

## Included
- Canvas-based ring fallback when THREE.WebGLRenderer cannot initialize
- Null-guard fixes preventing fallback-mode JS runtime errors
- Startup render loop initialization so idle visual appears immediately
- Subtle hidden-state idle glow so the desktop window is visibly alive

## Scope
- Frontend-only changes in frontend/index.html
- No backend, settings, dependency, or audio logic changes

## Validation
- Reproduced and handled Error creating WebGL context
- Verified fallback ring animates through listening/processing/responding states
- Verified idle glow is present on startup before first interaction