### PR TITLE
Fix Home Assistant TTS proxy URL handling for audio playback

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -223,7 +223,11 @@ def play_audio_from_url(url, host, animation_server=None, done_callback=None):
     
     try:
         import re as _re
-        _is_local = os.path.isabs(url) or _re.match(r'^[A-Za-z]:[/\\]', url)
+        _is_windows_abs = bool(_re.match(r'^[A-Za-z]:[/\\]', str(url)))
+        _looks_abs = os.path.isabs(url) or _is_windows_abs
+        # Treat as local only if it actually exists on disk.
+        # HA TTS URLs look like "/api/tts_proxy/..." and must be fetched over HTTP.
+        _is_local = _looks_abs and os.path.exists(url)
 
         if _is_local:
             local_path = os.path.normpath(url)


### PR DESCRIPTION
## Summary
Fixes TTS playback failures caused by treating Home Assistant proxy URLs like local filesystem paths.

## Problem
URLs such as /api/tts_proxy/<token>.mp3 were interpreted as local absolute paths, causing libsndfile open errors and no spoken response.

## Fix
- Treat path-like URLs as local only if the file actually exists on disk
- Keep /api/tts_proxy/... on the HTTP download path

## Scope
- Single-file bugfix in utils.py

## Validation
- Confirmed spoken responses play again using HA tts_proxy URLs
- Startup/shutdown sounds and existing output-device path remain unaffected