### PR TITLE
Client: harden websocket close during shutdown

### DIFF
--- a/client.py
+++ b/client.py
@@ -646,9 +646,15 @@ class HomeAssistantClient:
         """Close connection."""
         self.connected = False
         if self.websocket:
+            ws = self.websocket
+            self.websocket = None
             try:
-                await self.websocket.close()
-                logger.info("Connection closed")
+                await ws.close()
+                logger.debug("Connection closed")
+            except RuntimeError as e:
+                # During shutdown, the websocket can belong to another event loop/thread.
+                # This is safe to ignore because process teardown is in progress.
+                logger.warning(f"Connection close deferred due to loop mismatch: {e}")
             except Exception as e:
                 logger.error(f"Connection closing error: {e}")
     


### PR DESCRIPTION
## Summary
Splits client shutdown hardening out of superseded PR #33 into a focused change.

## Included
- Prevent double-close races by detaching self.websocket before awaiting close
- Handle RuntimeError loop-mismatch during teardown without crashing cleanup path
- Keep error logging for non-loop-related close failures

## Scope
- client.py only

## Validation
- Improves cleanup robustness in threaded/event-loop mixed shutdown flow
