### PR TITLE
FIX: Specify Inference Framework - onnx

### DIFF
--- a/wake_word_detector.py
+++ b/wake_word_detector.py
@@ -116,6 +116,7 @@ class WakeWordDetector:
                                 logger.info("Falling back to default openWakeWord models")
                     elif onnx_paths:
                         model_kwargs['wakeword_models'] = onnx_paths
+                        model_kwargs['inference_framework'] = 'onnx'
                         logger.info(f"Loading ONNX models on Linux: {', '.join(self.selected_models)}")
                     else:
                         logger.info("No custom models found, using defaults")
@@ -123,6 +124,7 @@ class WakeWordDetector:
                     # Windows: prefer ONNX, avoid TFLite due to compatibility issues
                     if onnx_paths:
                         model_kwargs['wakeword_models'] = onnx_paths
+                        model_kwargs['inference_framework'] = 'onnx'
                         logger.info(f"Loading ONNX models on Windows: {', '.join(self.selected_models)}")
                     elif tflite_paths:
                         logger.warning("Found .tflite models but tflite-runtime not reliable on Windows")


### PR DESCRIPTION
OpenWakeWord::Model defaults the inference_framework parameter to 'tflite'.

Explicitly set to onnx when using onnx paths.

I believe this was causing issues on my windows box as OpenWakeWord failed to import tflite runtime causing wakeword detection to be disabled.

[OpenWakeWord::Model](https://github.com/dscripka/openWakeWord/blob/368c03716d1e92591906a84949bc477f3a834455/openwakeword/model.py#L46)

In an attempt to be minimally invasive I did not specify the parameter for the tflite paths as they seem to be a sensible default.
(Also, I'm not a Python guy so less is safer for the world)

Also, awesome work.